### PR TITLE
Added ModInfo for RedirectLogs & Make use of env variables

### DIFF
--- a/RedirectLogs.cs
+++ b/RedirectLogs.cs
@@ -12,7 +12,15 @@ namespace VSExampleMods
     {
         public override ModInfo GetModInfo()
         {
-            return null;
+            return new ModInfo()
+            {
+                Name = "RedirectLogs",
+                Version = "1.0",
+                GameVersions = new string[] { "1.5+" },
+                Description = "Redirecting logs to VS",
+                Author = "Tyron",
+                Website = "https://github.com/anegostudios/vsmodexamples"
+            };
         }
 
         public override bool ShouldLoad(EnumAppSide side)

--- a/VSExampleMods.csproj
+++ b/VSExampleMods.csproj
@@ -37,7 +37,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory\Lib\protobuf-net.dll</HintPath>
+      <HintPath>$(AppData)\Vintagestory\Lib\protobuf-net.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -50,11 +50,11 @@
     <Reference Include="System.Xml" />
     <Reference Include="VintagestoryAPI, Version=1.0.10.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory\VintagestoryAPI.dll</HintPath>
+      <HintPath>$(AppData)\Vintagestory\VintagestoryAPI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="VSSurvivalMod">
-      <HintPath>..\..\..\AppData\Roaming\Vintagestory\Mods\VSSurvivalMod.dll</HintPath>
+      <HintPath>$(AppData)\Vintagestory\Mods\VSSurvivalMod.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VSExampleMods.csproj.user
+++ b/VSExampleMods.csproj.user
@@ -2,15 +2,15 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Users\tyron\AppData\Roaming\Vintagestory\Vintagestory.exe</StartProgram>
-    <StartArguments>--openWorld="modsamplestest" -p3 --addOrigin="C:\Users\tyron\Dropbox\vintagecraft\vsmodexamples\assets"</StartArguments>
+    <StartProgram>$(AppData)\Vintagestory\Vintagestory.exe</StartProgram>
+    <StartArguments>--openWorld="modsamplestest" -p3 --addOrigin="$(SolutionDir)assets"</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <StartAction>Program</StartAction>
-    <StartProgram>C:\Users\tyron\AppData\Roaming\Vintagestory\Vintagestory.exe</StartProgram>
+    <StartProgram>$(AppData)\Vintagestory\Vintagestory.exe</StartProgram>
     <StartArguments>/flatworld</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <ReferencePath>C:\Users\jchappelle\AppData\Roaming\Vintagestory\;C:\Users\jchappelle\AppData\Roaming\Vintagestory\Lib\</ReferencePath>
+    <ReferencePath>$(AppData)\Vintagestory\;$(AppData)\Vintagestory\Lib\</ReferencePath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Otherwise, if there is no ModInfo from any mod, the entire dll won't be loaded.